### PR TITLE
Incorporate more Yukon area types

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -184,13 +184,18 @@ export default {
           _.each(this.searchResults.areas, area => {
             // Skip all but HUCs and Protected Areas, the other polygons
             // get so big they cause the map interface to work poorly.
-            if (area.type != 'huc' && area.type != 'protected_area') {
+            if (
+              area.type != 'huc' &&
+              area.type != 'protected_area' &&
+              area.type != 'yt_watershed' &&
+              area.type != 'yt_game_management_subzone'
+            ) {
               return
             }
 
             let defaultStyle, highlightedStyle
             // Set up the layer styles for HUC/Protected area
-            if (area.type == 'huc') {
+            if (area.type == 'huc' || area.type == 'yt_watershed') {
               defaultStyle = hucDefaultStyle
               highlightedStyle = hucHighlightedStyle
             } else if (area.type == 'protected_area') {

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -198,7 +198,10 @@ export default {
             if (area.type == 'huc' || area.type == 'yt_watershed') {
               defaultStyle = hucDefaultStyle
               highlightedStyle = hucHighlightedStyle
-            } else if (area.type == 'protected_area') {
+            } else if (
+              area.type == 'protected_area' ||
+              area.type == 'yt_game_management_subzone'
+            ) {
               defaultStyle = protectedAreaDefaultStyle
               highlightedStyle = protectedAreaHighlightedStyle
             }

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -142,7 +142,7 @@ export default {
     drawSearchResults() {
       // This can be triggered before the data are ready;
       // guard!
-      if (this.searchResults) {
+      if (this.searchResults && this.searchResults.total_bounds) {
         // Clear prior results, if any.
         if (this.layerGroup || this.communityLayerGroup) {
           this.map.removeLayer(this.layerGroup)

--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -29,6 +29,12 @@
                 >
                 <span
                   class="area-additional-info"
+                  v-if="props.option.type == 'yt_watershed'"
+                >
+                  Yukon Watershed
+                </span>
+                <span
+                  class="area-additional-info"
                   v-if="props.option.type == 'protected_area'"
                 >
                   {{ props.option.area_type }}
@@ -59,6 +65,12 @@
                 </span>
                 <span
                   class="area-additional-info"
+                  v-if="props.option.type == 'yt_fire_district'"
+                >
+                  Yukon Fire District
+                </span>
+                <span
+                  class="area-additional-info"
                   v-if="props.option.type == 'first_nation'"
                 >
                   First Nation Traditional Territory
@@ -68,6 +80,12 @@
                   v-if="props.option.type == 'game_management_unit'"
                 >
                   Game Management Unit
+                </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'yt_game_management_subzone'"
+                >
+                  Yukon Game Management Subzone
                 </span>
                 <span
                   class="area-additional-info"
@@ -97,12 +115,14 @@
               <li>Alaska Game Management Units (GMUs)</li>
               <li>Alaska Native Corporations</li>
               <li>Boroughs and Census Areas</li>
+              <li>Ethnolinguistic Divisions</li>
+              <li>Yukon First Nation Traditional Territories</li>
+              <li>Yukon Fire Districts</li>
               <li>Communities in Alaska and Canada</li>
             </ul>
           </div>
           <div class="column">
             <ul>
-              <li>Ethnolinguistic Divisions</li>
               <li>
                 <strong>Hydrological units (HUs)</strong> searchable by HU Code
                 (HUC8, HUC10) and name
@@ -111,7 +131,11 @@
                 <strong>Protected areas</strong>&nbsp;&nbsp;National Parks and
                 more, searchable by name and agency
               </li>
-              <li>Yukon First Nation Traditional Territories</li>
+              <li>
+                <strong>Yukon Game Management Subzones</strong> searchable by
+                code
+              </li>
+              <li><strong>Yukon Watersheds</strong> searchable by code</li>
             </ul>
           </div>
         </div>

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -143,14 +143,23 @@ export default {
           placeType =
             'HUC' + (place.id.length == 10 ? '10 ' : '8 ') + 'ID' + place.id
           break
+        case 'yt_watershed':
+          placeType = 'Yukon Watershed'
+          break
         case 'climate_division':
           placeType = 'Climate Division'
           break
         case 'fire_zone':
           placeType = 'Fire Management Unit'
           break
+        case 'yt_fire_district':
+          placeType = 'Yukon Fire District'
+          break
         case 'game_management_unit':
           placeType = 'Game Management Unit'
+          break
+        case 'yt_game_management_subzone':
+          placeType = 'Yukon Game Management Subzone'
           break
         case 'first_nation':
           placeType = 'First Nation Traditional Territory'

--- a/store/place.js
+++ b/store/place.js
@@ -251,13 +251,22 @@ export const actions = {
         _.each(res.fire_management_units_near, place => {
           ssr.push(place)
         })
+        _.each(res.yt_fire_districts_near, place => {
+          ssr.push(place)
+        })
         _.each(res.hucs_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.yt_watersheds_near, place => {
           ssr.push(place)
         })
         _.each(res.protected_areas_near, place => {
           ssr.push(place)
         })
         _.each(res.game_management_units_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.yt_game_management_subzones_near, place => {
           ssr.push(place)
         })
         _.each(res.ca_first_nations_near, place => {

--- a/utils/path.js
+++ b/utils/path.js
@@ -9,10 +9,13 @@ export const getAppPathFragment = function (type, id) {
     type == 'climate_division' ||
     type == 'ethnolinguistic_region' ||
     type == 'fire_zone' ||
+    type == 'yt_fire_district' ||
     type == 'first_nation' ||
     type == 'game_management_unit' ||
+    type == 'yt_game_management_subzone' ||
     type == 'borough' ||
-    type == 'census_area'
+    type == 'census_area' ||
+    type == 'yt_watershed'
   ) {
     path = '/report/area/' + id
   } else {


### PR DESCRIPTION
This PR, along with its corresponding API PR (https://github.com/ua-snap/data-api/pull/407), incorporates the following Yukon areas into NCR:

- Yukon Fire Districts
- Yukon Game Management Subzones
- Yukon Watersheds

To test:

- `export SNAP_API_URL=http://localhost:5000`
- Run both the API and NCR from their respective `more_yukon_areas` branches.
- Try clicking a few areas within the Yukon territory on NCR's location search map. Verify that each of the new Yukon area types are represented in the search results. Similar to Alaska's Fire Management Zones, Yukon Fire District polygons are not drawn on the map because they can be quite large. But all three of the new Yukon area types should show up in the bulleted list of search results if they intersect the point to clicked.
- Load some reports for the new Yukon area types and verify that they load as expected & have some data.