### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -132,7 +132,7 @@ export default {
   },
 
   umami: {
-    scriptUrl: 'https://umami.snap.uaf.edu/umami.js',
+    scriptUrl: 'https://umami.snap.uaf.edu/script.js',
     websiteId: '2e69a077-ba5f-49c5-b076-09a44ab6fafd',
     ignoreDnt: false,
     domains: 'northernclimatereports.org',


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `nuxt.config.js` to:

```
umami: {
  scriptUrl: 'http://localhost:9999/script.js',
  websiteId: '2e69a077-ba5f-49c5-b076-09a44ab6fafd',
  ignoreDnt: false,
  // domains: 'northernclimatereports.org',
  ignoreLocalhost: true,
},
```

Then run NCR locally and verify that your traffic shows up here: http://localhost:9999/websites/2e69a077-ba5f-49c5-b076-09a44ab6fafd