### PR TITLE
Fix credits page bio centering at very wide resolutions

### DIFF
--- a/pages/credits.vue
+++ b/pages/credits.vue
@@ -301,6 +301,7 @@
     float: right;
     display: inline-block;
     padding-right: 1rem;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Closes #629.

This fixes the issue described in #629. The problem is that, at very wide resolutions, bio images cap out at their native width of 300px and are floated to the right. The extra whitespace to the left of the bio image gives the appearance of the grid system failing, even though it is still working as intended. This has been fixed by setting bio images to `width: 100%` so they scale up when their parent div is greater than 300px wide.

To test, run the app, view the credits page, and make your browser **very** wide (maybe even wider than your laptop screen). Verify that everything on the page still lines up as expected.