### PR TITLE
Tweak temperature qualitative text to clarify historical vs. projected

### DIFF
--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -212,7 +212,7 @@ export default {
       string +=
         '<p><strong>' +
         seasonWithHighestTempChange +
-        '</strong> temperatures are increasing the most (<strong>+' +
+        '</strong> temperatures are projected to increase the most (<strong>+' +
         annualHighestTempChange +
         this.tempUnitsText +
         '</strong>).</p>'


### PR DESCRIPTION
Closes #631.

This PR simply updates the temperature qualitative text per JL's recommendation to clarify that we're talking about trends in projected data, not historical data. I.e., instead of this:

> Winter temperatures are increasing the most (+16°F).

It now says this:

> Winter temperatures are projected to increase the most (+16°F).

To test, run the app and load the report for any location with temperature data to see the difference in qualitative text.