### PR TITLE
Redirect bad URL routes to the front page

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -128,6 +128,11 @@ export default {
         path: '/report/:lat/:lng',
         component: resolve(__dirname, 'pages/index'),
       })
+      routes.push({
+        name: 'default',
+        path: '*',
+        redirect: '/',
+      })
     },
   },
 


### PR DESCRIPTION
Closes #632.

This PR redirects unrecognized URL paths to the front page of the app, using the same Nuxt default route configuration we used for Arctic-EDS.

To test, run the app and enter any bogus URL path of your choosing (e.g., http://localhost:3000/foo/bar) and observe that the app redirects to the front page. All known routes should continue to work as expected.