### PR TITLE
Fixes incorrect place name rendering, specifically with degrees N and W for a point location.

### DIFF
--- a/components/reports/hydrology/ReportHydrologyTables.vue
+++ b/components/reports/hydrology/ReportHydrologyTables.vue
@@ -39,8 +39,8 @@
             mapVariables(variable)
           }},
 
-          <span v-html="place"></span>
-          , 1950&ndash;2099,
+          <span v-html="place"></span
+          >, 1950&ndash;2099,
           {{
             radioHydroModel
           }}

--- a/components/reports/hydrology/ReportHydrologyTables.vue
+++ b/components/reports/hydrology/ReportHydrologyTables.vue
@@ -38,9 +38,13 @@
           {{
             mapVariables(variable)
           }},
+
+          <span v-html="place"></span>
+          , 1950&ndash;2099,
           {{
-            place
-          }}, 1950&ndash;2099, {{ radioHydroModel }} model
+            radioHydroModel
+          }}
+          model
         </caption>
         <thead>
           <tr>


### PR DESCRIPTION
This PR Is a simple fix to allow for the rendering of the degree symbols when a point location is chosen in NCR in the Hydrology section table such as:

https://northernclimatereports.org/report/61.68/-149.26#hydrology

Fixes #649 