### PR TITLE
Use hyphens, not emdash, in email address

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -31,7 +31,7 @@
             <strong
               >Please contact
               <a href="mailto:uaf-snap-data-tools@alaska.edu"
-                >uaf&ndash;snap&ndash;data&ndash;tools@alaska.edu</a
+                >uaf-snap-data-tools@alaska.edu</a
               >
               with questions or comments.</strong
             >


### PR DESCRIPTION
Test that copy/pasting in Safari 17 + other browsers yields a successful copy/paste (you can inspect it in Vim or similar to ensure we aren't getting unicode).