### PR TITLE
Mark a place with its region if it's a point location

### DIFF
--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -75,6 +75,9 @@
                 >
                   Borough
                 </span>
+                <span class="area-additional-info">
+                  {{ props.option.region }}
+                </span>
               </div>
             </template>
           </b-autocomplete>


### PR DESCRIPTION
Closes #662 

The `region` property is now included in the search result dropdown.

Testing: search for a variety of places.  Note that "Alaska" and "Yukon" etc are appended for point locations.