### PR TITLE
Limit tags to just NCR

### DIFF
--- a/store/place.js
+++ b/store/place.js
@@ -227,7 +227,7 @@ export const actions = {
   },
 
   async fetchPlaces(context) {
-    let queryUrl = process.env.apiUrl + '/places/all'
+    let queryUrl = process.env.apiUrl + '/places/all?tags=ncr'
     let localKey = 'places'
     let returnedData = await localStorage(queryUrl, localKey)
     context.commit('setPlaces', returnedData)
@@ -243,7 +243,8 @@ export const actions = {
         '/places/search/' +
         context.getters.latLng[0] +
         '/' +
-        context.getters.latLng[1]
+        context.getters.latLng[1] +
+        '?tags=ncr'
 
       await this.$http.$get(queryUrl).then(res => {
         // Change the object structure to flatten & sort the areas


### PR DESCRIPTION
Closes #688 

To test this:
- Run local API instance per [this ticket](https://github.com/ua-snap/data-api/pull/497) (but you can run it against `main` now).
- Run the app and search for "Nike".  You should not see anything.
- Scroll to the map and click on/near Eielson.  You should not see Nike Alaska Charlie or Nike Alaska Mike.


