### PR TITLE
Stop mentioning "vegetation change" twice in report introduction

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -432,9 +432,9 @@ export default {
       // (Temperature, Permafrost, Beetle Climate Protection, etc.)
       let types = this.presentDataTypes()
 
-      // If there are less than 9 data types present, the corresponding
+      // If there are less than 8 data types present, the corresponding
       // section(s) of the report page will be hidden.
-      if (types.length < 9) {
+      if (types.length < 8) {
         return true
       }
       return false
@@ -560,9 +560,6 @@ export default {
       }
       if (this.beetleData) {
         types.push('climate protection from spruce beetle outbreaks')
-      }
-      if (this.vegChangeData) {
-        types.push('vegetation change')
       }
       if (this.demographicsData) {
         types.push('demographics')


### PR DESCRIPTION
This PR fixes the bug that was causing "vegetation change" to be listed twice, for locations where vegetation data is available:

![image](https://github.com/user-attachments/assets/a7e0115e-ff73-4d31-8da6-10f4fadb55a7)

This was caused by this same chunk of code being repeated twice in `Report.vue`:

```
if (this.vegChangeData) {
  types.push('vegetation change')
}
```

Not sure how it got this way, but probably just a copy & paste accident somewhere along the way.

I've also updated the line of code that detects if all possible data types exist for the location, and lists the missing data types if any are detected as missing. The maximum number of data types on a report is now 8, not 9, with the extra "vegetation change" type removed.

To test:

- Load a report for Fairbanks or any other location that has vegetation data. Confirm that "vegetation change" is mentioned only once in the introduction.
- Load a report for a location with at least one type of data missing (e.g., Nome), and confirm that the page accurately lists the dataset that is missing.