### PR TITLE
Fixes permafrost and hydrology fetches so that area calls are not made, no such endpoint exists on the API.

### DIFF
--- a/store/hydrology.js
+++ b/store/hydrology.js
@@ -204,20 +204,25 @@ export const mutations = {
 
 export const actions = {
   async fetch(context) {
-    let queryUrl =
-      process.env.apiUrl +
-      '/eds/hydrology/' +
-      context.rootGetters['place/urlFragment']()
+    // Only fetches data if the url fragment contains 'point'
+    if (context.rootGetters['place/urlFragment']().includes('point')) {
+      let queryUrl =
+        process.env.apiUrl +
+        '/eds/hydrology/' +
+        context.rootGetters['place/urlFragment']()
 
-    let returnedData = await $axios
-      .get(queryUrl, { timeout: 60000 })
-      .catch(err => {
-        console.error(err)
-        context.commit('setHttpError', 'server_error')
-      })
+      let returnedData = await $axios
+        .get(queryUrl, { timeout: 60000 })
+        .catch(err => {
+          console.error(err)
+          context.commit('setHttpError', 'server_error')
+        })
 
-    if (returnedData) {
-      context.commit('setHydrologyData', returnedData.data.summary)
+      if (returnedData) {
+        context.commit('setHydrologyData', returnedData.data.summary)
+      } else {
+        context.commit('setHttpError', 'no_data')
+      }
     } else {
       context.commit('setHttpError', 'no_data')
     }

--- a/store/hydrology.js
+++ b/store/hydrology.js
@@ -205,7 +205,7 @@ export const mutations = {
 export const actions = {
   async fetch(context) {
     // Only fetches data if the url fragment contains 'point'
-    if (context.rootGetters['place/urlFragment']().includes('point')) {
+    if (context.rootGetters['place/isPointLocation']) {
       let queryUrl =
         process.env.apiUrl +
         '/eds/hydrology/' +

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -136,7 +136,7 @@ export const mutations = {
 export const actions = {
   async fetch(context) {
     // Only fetches data if the url fragment contains 'point'
-    if (context.rootGetters['place/urlFragment']().includes('point')) {
+    if (context.rootGetters['place/isPointLocation']) {
       let queryUrl =
         process.env.apiUrl +
         '/ncr/permafrost/' +


### PR DESCRIPTION
This PR fixes the requests to permafrost and hydrology that don't have an API endpoints associated with area queries. These were causing errors and a long request time for something that doesn't exist on the backend.