### PR TITLE
Fixes HTTP errors and prevents code from executing if an HTTP error was given

### DIFF
--- a/store/beetle.js
+++ b/store/beetle.js
@@ -1,5 +1,5 @@
 // This store manages ALFRESCO data!
-import _, { get } from 'lodash'
+import _ from 'lodash'
 import $axios from 'axios'
 import { getHttpError } from '../utils/http_errors'
 

--- a/store/beetle.js
+++ b/store/beetle.js
@@ -1,6 +1,7 @@
 // This store manages ALFRESCO data!
-import _ from 'lodash'
+import _, { get } from 'lodash'
 import $axios from 'axios'
+import { getHttpError } from '../utils/http_errors'
 
 export const state = () => ({
   beetleData: undefined,
@@ -88,21 +89,22 @@ export const actions = {
     let returnedData = await $axios
       .get(queryUrl, { timeout: 60000 })
       .catch(err => {
-        console.error(err)
-        context.commit('setHttpError', 'server_error')
+        context.commit('setHttpError', getHttpError(err))
       })
 
-    let partialData = false
-    expectedDataKeys.forEach(key => {
-      if (returnedData.data[key] == null) {
-        partialData = true
-      }
-    })
+    if (returnedData) {
+      let partialData = false
+      expectedDataKeys.forEach(key => {
+        if (returnedData.data[key] == null) {
+          partialData = true
+        }
+      })
 
-    if (partialData) {
-      context.commit('setHttpError', 'no_data')
-    } else if (returnedData && !partialData) {
-      context.commit('setBeetleData', returnedData.data)
+      if (partialData) {
+        context.commit('setHttpError', 'no_data')
+      } else if (returnedData && !partialData) {
+        context.commit('setBeetleData', returnedData.data)
+      }
     }
   },
 }

--- a/store/climate.js
+++ b/store/climate.js
@@ -1,5 +1,5 @@
 // This store fetches/manages "climate" variables (taspr = temp + precip)
-import _, { get } from 'lodash'
+import _ from 'lodash'
 import { convertToInches, convertToFahrenheit } from '../utils/convert'
 import $axios from 'axios'
 import { getHttpError } from '../utils/http_errors'

--- a/store/climate.js
+++ b/store/climate.js
@@ -1,7 +1,8 @@
 // This store fetches/manages "climate" variables (taspr = temp + precip)
-import _ from 'lodash'
+import _, { get } from 'lodash'
 import { convertToInches, convertToFahrenheit } from '../utils/convert'
 import $axios from 'axios'
+import { getHttpError } from '../utils/http_errors'
 
 // Helper functions
 var convertReportData = function (climateData) {
@@ -95,21 +96,22 @@ export const actions = {
     let returnedData = await $axios
       .get(queryUrl, { timeout: 60000 })
       .catch(err => {
-        console.error(err)
-        context.commit('setHttpError', 'server_error')
+        context.commit('setHttpError', getHttpError(err))
       })
 
-    let partialData = false
-    expectedDataKeys.forEach(key => {
-      if (returnedData.data[key] == null) {
-        partialData = true
-      }
-    })
+    if (returnedData) {
+      let partialData = false
+      expectedDataKeys.forEach(key => {
+        if (returnedData.data[key] == null) {
+          partialData = true
+        }
+      })
 
-    if (partialData) {
-      context.commit('setHttpError', 'no_data')
-    } else if (returnedData && !partialData) {
-      context.commit('setClimateData', returnedData.data)
+      if (partialData) {
+        context.commit('setHttpError', 'no_data')
+      } else if (returnedData && !partialData) {
+        context.commit('setClimateData', returnedData.data)
+      }
     }
   },
 }

--- a/store/demographics.js
+++ b/store/demographics.js
@@ -1,5 +1,7 @@
+import { get } from 'lodash'
 import demographics from '../assets/demographics.json'
 import $axios from 'axios'
+import { getHttpError } from '../utils/http_errors'
 
 export const state = () => ({
   demographicsData: undefined,
@@ -60,8 +62,7 @@ export const actions = {
           // Forbidden means adult population < 50
           context.commit('setHttpError', 'low_population')
         } else {
-          console.error(error)
-          context.commit('setHttpError', 'no_data')
+          context.commit('setHttpError', getHttpError(error))
         }
       })
 
@@ -79,8 +80,7 @@ export const actions = {
     let returnedGeometry = await $axios
       .get(geometryQueryUrl, { timeout: 60000 })
       .catch(err => {
-        console.error(err)
-        context.commit('setHttpError', 'no_data')
+        context.commit('setHttpError', getHttpError(err))
       })
 
     if (returnedData && returnedGeometry) {

--- a/store/demographics.js
+++ b/store/demographics.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash'
 import demographics from '../assets/demographics.json'
 import $axios from 'axios'
 import { getHttpError } from '../utils/http_errors'

--- a/store/elevation.js
+++ b/store/elevation.js
@@ -1,5 +1,6 @@
 import { convertToFeet } from '../utils/convert'
 import $axios from 'axios'
+import { getHttpError } from '../utils/http_errors'
 
 export const state = () => ({
   elevation: undefined,
@@ -65,8 +66,7 @@ export const actions = {
     let returnedData = await $axios
       .get(queryUrl, { timeout: 60000 })
       .catch(err => {
-        console.error(err)
-        context.commit('setHttpError', 'server_error')
+        context.commit('setHttpError', getHttpError(err))
       })
     if (returnedData) {
       context.commit('setElevation', returnedData.data)

--- a/store/hydrology.js
+++ b/store/hydrology.js
@@ -1,5 +1,5 @@
 // This store fetches/manages "climate" variables (taspr = temp + precip)
-import _, { get } from 'lodash'
+import _ from 'lodash'
 import { convertMmToInches, convertToFahrenheit } from '../utils/convert'
 import $axios from 'axios'
 import { getHttpError } from '../utils/http_errors'

--- a/store/hydrology.js
+++ b/store/hydrology.js
@@ -1,7 +1,8 @@
 // This store fetches/manages "climate" variables (taspr = temp + precip)
-import _ from 'lodash'
+import _, { get } from 'lodash'
 import { convertMmToInches, convertToFahrenheit } from '../utils/convert'
 import $axios from 'axios'
+import { getHttpError } from '../utils/http_errors'
 
 // Helper functions
 var convertReportData = function (hydrologyData) {
@@ -214,8 +215,7 @@ export const actions = {
       let returnedData = await $axios
         .get(queryUrl, { timeout: 60000 })
         .catch(err => {
-          console.error(err)
-          context.commit('setHttpError', 'server_error')
+          context.commit('setHttpError', getHttpError(err))
         })
 
       if (returnedData) {

--- a/store/indicators.js
+++ b/store/indicators.js
@@ -2,6 +2,7 @@
 import _ from 'lodash'
 import { convertMmToInches, convertValueToFahrenheit } from '../utils/convert'
 import $axios from 'axios'
+import { getHttpError } from '../utils/http_errors'
 
 var convertTemperatureData = function (obj) {
   if (typeof obj === 'number') {
@@ -90,8 +91,7 @@ export const actions = {
     let returnedData = await $axios
       .get(queryUrl, { timeout: 60000 })
       .catch(err => {
-        console.error(err)
-        context.commit('setHttpError', 'server_error')
+        context.commit('setHttpError', getHttpError(err))
       })
 
     if (returnedData) {

--- a/store/place.js
+++ b/store/place.js
@@ -1,6 +1,7 @@
 // Shim for dev/testing
 import _ from 'lodash'
 import $axios from 'axios'
+import { getHttpError } from '../utils/http_errors'
 
 // Store, namespaced as `place/`
 export const state = () => ({
@@ -229,10 +230,10 @@ export const actions = {
   async fetchPlaces(context) {
     const queryUrl = process.env.apiUrl + '/places/all?tags=ncr'
     try {
-      const returnedData = await $axios.get(queryUrl, { timeout: 60000 })
+      const returnedData = await $axios.get(queryUrl, { timeout: 10000 })
       context.commit('setPlaces', returnedData.data)
     } catch (error) {
-      console.error('Error fetching places:', error)
+      console.error('Error fetching places:', getHttpError(error))
       // Optionally handle the error, e.g., show an error message to the user
       context.commit('setPlaces', null) // Or handle the error case appropriately
     }

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -1,5 +1,5 @@
 // This store manages ALFRESCO data!
-import _, { get } from 'lodash'
+import _ from 'lodash'
 import { convertToPercent } from '../utils/convert'
 import $axios from 'axios'
 import { getHttpError } from '../utils/http_errors'

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -1,7 +1,8 @@
 // This store manages ALFRESCO data!
-import _ from 'lodash'
+import _, { get } from 'lodash'
 import { convertToPercent } from '../utils/convert'
 import $axios from 'axios'
+import { getHttpError } from '../utils/http_errors'
 
 // Store, namespaced as `climate/`
 export const state = () => ({
@@ -214,20 +215,22 @@ export const actions = {
       .get(queryUrl, { timeout: 60000 })
       .catch(err => {
         console.error(err)
-        context.commit('setFlammabilityHttpError', 'server_error')
+        context.commit('setFlammabilityHttpError', getHttpError(err))
       })
 
-    let partialData = false
-    expectedFlamKeys.forEach(key => {
-      if (returnedData.data[key] == null) {
-        partialData = true
-      }
-    })
+    if (returnedData) {
+      let partialData = false
+      expectedFlamKeys.forEach(key => {
+        if (returnedData.data[key] == null) {
+          partialData = true
+        }
+      })
 
-    if (partialData) {
-      context.commit('setFlammabilityHttpError', 'no_data')
-    } else if (returnedData && !partialData) {
-      context.commit('setFlammability', convertToPercent(returnedData.data))
+      if (partialData) {
+        context.commit('setFlammabilityHttpError', 'no_data')
+      } else if (returnedData && !partialData) {
+        context.commit('setFlammability', convertToPercent(returnedData.data))
+      }
     }
 
     queryUrl =
@@ -241,21 +244,22 @@ export const actions = {
     let expectedVegKeys = ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
 
     returnedData = await $axios.get(queryUrl, { timeout: 60000 }).catch(err => {
-      console.error(err)
-      context.commit('setHttpError', 'server_error')
+      context.commit('setHttpError', getHttpError(err))
     })
 
-    partialData = false
-    expectedVegKeys.forEach(key => {
-      if (returnedData.data[key] == null) {
-        partialData = true
+    if (returnedData) {
+      let partialData = false
+      expectedVegKeys.forEach(key => {
+        if (returnedData.data[key] == null) {
+          partialData = true
+        }
+      })
+
+      if (partialData) {
+        context.commit('setHttpError', 'no_data')
+      } else if (returnedData && !partialData) {
+        context.commit('setVegChange', returnedData.data)
       }
-    })
-
-    if (partialData) {
-      context.commit('setHttpError', 'no_data')
-    } else if (returnedData && !partialData) {
-      context.commit('setVegChange', returnedData.data)
     }
   },
 }


### PR DESCRIPTION
This PR collects the correct HTTP response from the error provided by the fetch functions in each of the stores rather than defaulting to the server_error. This was showing up as bad requests in the output about why a certain section of the report was not filled in.

This also prevents code from being executed if the request does not complete successfully for a few of the stores: beetles, climate, permafrost, and wildfire. 

For an example of the difference seen in the console window, go to these two URLs:

- https://northernclimatereports.org/report/area/YTFD11#results
- http://localhost:3000/report/area/YTFD11#results