### PR TITLE
Indicate that no demographics data are available at unsupported locations

### DIFF
--- a/store/demographics.js
+++ b/store/demographics.js
@@ -50,6 +50,7 @@ export const actions = {
     // If placeId isn't defined, we don't have demographics for
     // this place.
     if (!placeId) {
+      context.commit('setHttpError', 'no_data')
       return
     }
 


### PR DESCRIPTION
Closes #707.

If you look at the example "problem" & "no problem" URLs listed in issue #707, the thing that all of the problem URLs have in common is that all possible datasets are available for the lat/lon coordinate. The only thing that's missing is demographics because we don't show demographics data for raw lat/lon coordinates, only named communities.

The problem here is that we are returning without setting an error code for demographics data for unsupported locations (lat/lon coordinates, most area types), so if all other datasets are available, the webapp recognizes that there's a dataset missing but lists nothing under "The following data is not available at this location:".

To fix this, I'm setting the demographics httpError to `no_data` for unsupported area types. I thought about implementing a custom "No data for unsupported place types" error message, but decided against it because I think the standard "No data at this location " message is sufficient.

To test, load the webapp and check out the following URLs:

http://localhost:3000/report/66.00/-148.00
http://localhost:3000/report/66.00/-149.00
http://localhost:3000/report/66.00/-150.00

Confirm that each of the those report pages says "Demographics: No data at this location" under the "The following data is not available at this location:" section.

