### PR TITLE
Fix "not modeled or no data" color in flammability legend to match mini-maps

### DIFF
--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -47,7 +47,7 @@ export const getters = {
     return [
       {
         label: 'Not modeled or no data',
-        color: '#ffffff',
+        color: '#dddddd',
         interpretation:
           'This pixel was not modeled or is not included in the dataset',
       },


### PR DESCRIPTION
Closes #706.

Somewhere along the way, and for mysterious reasons, the Flammability "not modeled or no data" color changed from `#ffffff` to `#dddddd`. I've tried updating the color map for the coverage on Zeus (a test coverage actually) and nothing seems to fix this, so this PR updates the legend for the Flammability mini-maps to reflect the new color.

As mentioned in issue #705, The Vegetation Type mini-maps were having a similar problem until recently, so those mini-maps currently match their map legend. I think the Vegetation Type maps may have fixed themselves during the most recent Rasdaman upgrade 🤷 