### PR TITLE
Revert nodata color to white in Flammability mini-map legend

### DIFF
--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -47,7 +47,7 @@ export const getters = {
     return [
       {
         label: 'Not modeled or no data',
-        color: '#dddddd',
+        color: '#ffffff',
         interpretation:
           'This pixel was not modeled or is not included in the dataset',
       },


### PR DESCRIPTION
Closes #710.

This PR simply sets the nodata color back to `#ffffff` in the Flammability mini-map legend now that we know how to set the WMS nodata color back to white using the following WCPS query in Rasdaman:

```
($c) null mask discard
```

However, since we recently pushed our quick fix (map legend nodata color of `#dddddd`) into production, I've not yet added the WCPS query above to the `alfresco_relative_flammability_30yr` coverage on Zeus so that the Flammability mini-maps and legend are in agreement (nodata color of `#dddddd`). Once this PR is merged and deployed into production, we just need to remember to add the WCPS query above to the `alfresco_relative_flammability_30yr` coverage on Zeus to make nodata white again.