### PR TITLE
Update SDOH dataset name throughout webapp and mention 90% confidence level in health section

### DIFF
--- a/components/reports/demographics/DemographicsOther.vue
+++ b/components/reports/demographics/DemographicsOther.vue
@@ -5,7 +5,7 @@
         <caption>
           <a
             href="https://odphp.health.gov/healthypeople/priority-areas/social-determinants-health"
-            >Social determinants of health</a
+            >Non-medical factor measures</a
           >,
           {{
             placeName
@@ -69,7 +69,7 @@
     <div v-else>
       <div class="content is-size-5">
         <p>
-          Some social determinants of health (minority status, high school
+          Some non-medical factor measures (minority status, high school
           diploma, living below 150% of poverty line, broadband and more) are
           not available for this location.
         </p>
@@ -145,7 +145,7 @@
       <div v-else>
         <div class="content is-size-5">
           <p>
-            Demographic information for social determinants of health and
+            Demographic information for non-medical factor measures and
             disability status are not available for this location.
           </p>
         </div>

--- a/components/reports/demographics/DemographicsReport.vue
+++ b/components/reports/demographics/DemographicsReport.vue
@@ -61,12 +61,15 @@
             >Learn more about the data sources here</nuxt-link
           >
           or <a :href="demographicsCsvUrl">download a CSV</a> for definitions
-          and sources for each variable. Confidence intervals (shown in
-          parentheses for each value) show the range where the true value is
-          likely to fall, based on the data collected. For example, if a
-          confidence interval is 45%&ndash;50%, it means we're confident the
-          true value is between 45% and 50%. Wider intervals suggest more
-          uncertainty, while narrower intervals mean more precise estimates.
+          and sources for each variable.
+        </p>
+        <p>
+          Confidence intervals (shown in parentheses for each value) show the
+          range where the true value is likely to fall, based on the data
+          collected, with a 90% confidence level. For example, if a confidence
+          interval is 45%&ndash;50%, it means we're 90% confident the true value
+          is between 45% and 50%. Wider intervals suggest more uncertainty,
+          while narrower intervals mean more precise estimates.
         </p>
         <p>
           <strong>How do I interpret these data?</strong> The indicators below

--- a/pages/data.vue
+++ b/pages/data.vue
@@ -32,10 +32,10 @@
                 <td>
                   <p>
                     Derived from the 2020 U.S. Census Demographics and Housing
-                    Characteristics File (DHC), the 2018-2022 U.S. Census
+                    Characteristics File (DHC), the 2019-2023 U.S. Census
                     American Community Survey (ACS) 5-year dataset, the 2024 CDC
-                    PLACES dataset, and the 2017-2021 CDC Social Determinants of
-                    Health (SDOH) dataset.
+                    PLACES dataset, and the 2017-2021 CDC Non-Medical Factor
+                    Measures dataset.
                   </p>
                   <p>Citations:</p>
                   <ul>
@@ -48,8 +48,8 @@
                       >
                     </li>
                     <li>
-                      U.S. Census Bureau (2021). 2018-2022 American Community
-                      Survey 5-year estimates. Accessed May 2024, from
+                      U.S. Census Bureau (2023). 2019-2023 American Community
+                      Survey 5-year estimates. Accessed March 2025, from
                       <a
                         href="https://www.census.gov/programs-surveys/acs/data.html"
                         >https://www.census.gov/programs-surveys/acs/data.html</a
@@ -60,6 +60,17 @@
                       Accessed November 2024, from
                       <a href="https://www.cdc.gov/places"
                         >https://www.cdc.gov/places</a
+                      >
+                    </li>
+                    <li>
+                      2017-2021 CDC Non-Medical Factor Measures. Healthy People
+                      2030, U.S. Department of Health and Human Services, Office
+                      of Disease Prevention and Health Promotion. Accessed
+                      February 2025, from
+                      <a
+                        href="https://health.gov/healthypeople/objectives-and-data/social-determinants-health"
+                      >
+                        https://health.gov/healthypeople/objectives-and-data/social-determinants-health</a
                       >
                     </li>
                   </ul>


### PR DESCRIPTION
Closes #717.
Closes #718.

This PR updates the webapp to say "Non-medical factor measures" instead of "Social determinants of health" here:

![image](https://github.com/user-attachments/assets/94443470-1e0c-45c1-b3da-5293e2d59648)

It also adds a citation for this dataset to the Data page:

![image](https://github.com/user-attachments/assets/7448b560-8dfb-4f8c-b06d-5c21f63e3d6c)

And also mentions the "90% confidence level" in the Health section's intro text:

![image](https://github.com/user-attachments/assets/aed863b6-7708-4b4c-9b6b-7bf11117134c)

You can see these changes for yourself by running the webapp like so:

```
nvm use lts/gallium
npm run dev
```

And view the app at http://localhost:3000/