### PR TITLE
Avoid claims that ALFRESCO datasets are available and not available at the same time, and other fixes

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -176,8 +176,9 @@
               depending on the presence or absence of permafrost
             </li>
             <li v-if="flammabilityData || vegChangeData">
-              <a href="#wildfire">Wildfire</a> charts of flammability and
-              vegetation change with with multiple models and scenarios
+              <a href="#wildfire">Wildfire</a> charts of
+              {{ wildfireDataSubstring }} with with multiple models and
+              scenarios
             </li>
             <li v-if="beetleData">
               <a href="#climate-protection-beetles"
@@ -496,6 +497,7 @@ export default {
       permafrostHttpError: 'permafrost/httpError',
       flammabilityHttpError: 'wildfire/flammabilityHttpError',
       vegChangeHttpError: 'wildfire/vegChangeHttpError',
+      wildfireDataSubstring: 'wildfire/wildfireDataSubstring',
       beetleHttpError: 'beetle/httpError',
       hydrologyHttpError: 'hydrology/httpError',
       demographicsHttpError: 'demographics/httpError',

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -177,7 +177,7 @@
             </li>
             <li v-if="flammabilityData || vegChangeData">
               <a href="#wildfire">Wildfire</a> charts of
-              {{ wildfireDataSubstring }} with with multiple models and
+              {{ wildfireDataSubstring }} with multiple models and
               scenarios
             </li>
             <li v-if="beetleData">

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -37,9 +37,10 @@
     <div class="content mb-6">
       <p>
         This table is a legend for the maps above, and explains different
-        categories of modeled fire activity shown on the chart below. These
-        categories are also used in the short blurb in the introduction to this
-        report.
+        categories of modeled fire activity<span v-if="flammabilityData">
+          shown on the chart below. These categories are also used in the short
+          blurb in the introduction to this report</span
+        >.
       </p>
       <ColorTable
         unitLabel="Flammability"
@@ -48,20 +49,22 @@
         :borderedColors="[0]"
       />
     </div>
-    <div class="content mt-6 pt-6">
-      <p class="is-size-5">
-        Hovering over the future eras shown on the chart shows the difference
-        between 1980&ndash;2009 and the future era.
-      </p>
+    <div v-if="flammabilityData">
+      <div class="content mt-6 pt-6">
+        <p class="is-size-5">
+          Hovering over the future eras shown on the chart shows the difference
+          between 1980&ndash;2009 and the future era.
+        </p>
+      </div>
+      <div class="chart-wrapper">
+        <ReportFlammabilityChart />
+      </div>
+      <DownloadCsvButton
+        text="Download flammability data as CSV"
+        endpoint="flammability"
+        class="mt-3 mb-5"
+      />
     </div>
-    <div class="chart-wrapper">
-      <ReportFlammabilityChart />
-    </div>
-    <DownloadCsvButton
-      text="Download flammability data as CSV"
-      endpoint="flammability"
-      class="mt-3 mb-5"
-    />
     <BackToTopButton />
     <div class="content">
       <div class="is-size-5 mt-6">
@@ -80,14 +83,16 @@
       </div>
     </div>
     <ReportVegChangeMaps />
-    <div class="chart-wrapper">
-      <ReportVegChangeChart />
+    <div v-if="vegChangeData">
+      <div class="chart-wrapper">
+        <ReportVegChangeChart />
+      </div>
+      <DownloadCsvButton
+        text="Download vegetation change data as CSV"
+        endpoint="veg_type"
+        class="mt-3 mb-5"
+      />
     </div>
-    <DownloadCsvButton
-      text="Download vegetation change data as CSV"
-      endpoint="veg_type"
-      class="mt-3 mb-5"
-    />
     <BackToTopButton />
   </div>
 </template>
@@ -139,6 +144,8 @@ export default {
       isPointLocation: 'place/isPointLocation',
       huc12Id: 'wildfire/huc12Id',
       place: 'place/name',
+      flammabilityData: 'wildfire/flammability',
+      vegChangeData: 'wildfire/veg_change',
     }),
   },
 }

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -144,6 +144,16 @@ export const getters = {
   vegChangeHttpError(state) {
     return state.vegChangeHttpError
   },
+  wildfireDataSubstring(state) {
+    let availableData = []
+    if (state.flammability) {
+      availableData.push('flammability')
+    }
+    if (state.veg_change) {
+      availableData.push('vegetation change')
+    }
+    return availableData.join(' and ')
+  },
   valid(state) {
     if (
       _.isObject(state.flammability) &&
@@ -244,7 +254,7 @@ export const actions = {
     let expectedVegKeys = ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
 
     returnedData = await $axios.get(queryUrl, { timeout: 60000 }).catch(err => {
-      context.commit('setHttpError', getHttpError(err))
+      context.commit('setVegChangeHttpError', getHttpError(err))
     })
 
     if (returnedData) {
@@ -256,7 +266,7 @@ export const actions = {
       })
 
       if (partialData) {
-        context.commit('setHttpError', 'no_data')
+        context.commit('setVegChangeHttpError', 'no_data')
       } else if (returnedData && !partialData) {
         context.commit('setVegChange', returnedData.data)
       }


### PR DESCRIPTION
Closes #696.

This PR solves the problem described in #696. Thus far, all of the logic around the ALFRESCO endpoints assumes that both wildfire and vegetation change data are either both missing or both present, and one can never be present without the other. This PR fixes this behavior in several places such as:

- The "Wildfire" entry in the table of contents
- References to the flammability charts in the Wildfire section's text
- Hides the CSV download button for the dataset if only one wildfire dataset is missing

Deliberately, the webapp still always showing both the flammability and vegetation change minimaps even if chart data is not available for one of the datasets. This is to be consistent with our decision to always show permafrost minimaps even if permafrost data is not available (because the area surrounding the selected point location is still valuable information to share). However, the entire Wildfire section (including both flammability and vegetation change) will be hidden if both datasets are missing.

I also fixed a couple spots in the `wildfire.js` store that were referencing `setHttpError` instead of `setVegChangeHttpError`. Frankly, I don't know how this worked before because there is no `setHttpError` setter function defined in the file 🤷 

To test this PR, change this line:

https://github.com/ua-snap/northern-climate-reports/blob/201246b263fea0807a536e6952398e153af00f6b/store/wildfire.js#L210

Or this line:

https://github.com/ua-snap/northern-climate-reports/blob/201246b263fea0807a536e6952398e153af00f6b/store/wildfire.js#L248

To a bogus URL to purposefully break one of the endpoints (but not both at the same time). Then verify that the report page adjusts to the missing dataset in a sane way.
