### PR TITLE
Rename "Game Management Unit" and "Fire Management Unit" category labels, and combine Alaska/Yukon watersheds in map search results

### DIFF
--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -61,7 +61,7 @@
                   class="area-additional-info"
                   v-if="props.option.type == 'fire_zone'"
                 >
-                  Fire Management Unit
+                  Alaska Fire Management Unit
                 </span>
                 <span
                   class="area-additional-info"
@@ -79,7 +79,7 @@
                   class="area-additional-info"
                   v-if="props.option.type == 'game_management_unit'"
                 >
-                  Game Management Unit
+                  Alaska Game Management Unit
                 </span>
                 <span
                   class="area-additional-info"

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -34,11 +34,11 @@
       </ul>
     </div>
 
-    <div v-if="searchBlocks.hucs.length">
-      <h4 class="subtitle is-6 mt-5 mb-1">Hydrological units (HUCs)</h4>
+    <div v-if="searchBlocks.watersheds.length">
+      <h4 class="subtitle is-6 mt-5 mb-1">Watersheds</h4>
       <ul>
         <li
-          v-for="place in searchBlocks.hucs"
+          v-for="place in searchBlocks.watersheds"
           :key="place.id"
           class="additional-info"
         >
@@ -116,11 +116,11 @@ export default {
     searchBlocks() {
       let blocks = {}
       blocks.communities = this.searchResults.communities
-      blocks.hucs = _.filter(this.searchResults.areas, area => {
-        return area.type == 'huc'
+      blocks.watersheds = _.filter(this.searchResults.areas, area => {
+        return area.type == 'huc' || area.type == 'yt_watershed'
       })
       blocks.areas = _.filter(this.searchResults.areas, area => {
-        return area.type != 'huc'
+        return area.type != 'huc' && area.type != 'yt_watershed'
       })
       return blocks
     },

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -150,13 +150,13 @@ export default {
           placeType = 'Climate Division'
           break
         case 'fire_zone':
-          placeType = 'Fire Management Unit'
+          placeType = 'Alaska Fire Management Unit'
           break
         case 'yt_fire_district':
           placeType = 'Yukon Fire District'
           break
         case 'game_management_unit':
-          placeType = 'Game Management Unit'
+          placeType = 'Alaska Game Management Unit'
           break
         case 'yt_game_management_subzone':
           placeType = 'Yukon Game Management Subzone'

--- a/pages/places.vue
+++ b/pages/places.vue
@@ -142,7 +142,7 @@
             </figure>
           </div>
           <div class="card-content">
-            <h3 class="title is-4">Fire Management Units</h3>
+            <h3 class="title is-4">Alaska Fire Management Units</h3>
             <div class="content">
               <p>
                 The
@@ -169,7 +169,7 @@
             </figure>
           </div>
           <div class="card-content">
-            <h3 class="title is-4">Game Management Units</h3>
+            <h3 class="title is-4">Alaska Game Management Units</h3>
             <div class="content">
               <p>
                 The Alaska Department of Fish and Game manages hunting by
@@ -251,8 +251,7 @@
                 Fire districts are administrative areas where wildland fire
                 resources are allocated and deployed. They fall within one of
                 six larger fire regions.
-                <a
-                  href="https://wildfires.service.yukon.ca/"
+                <a href="https://wildfires.service.yukon.ca/"
                   >Learn more about Yukon Fire Districts</a
                 >
               </p>

--- a/store/place.js
+++ b/store/place.js
@@ -138,13 +138,13 @@ export const getters = {
         case 'ethnolinguistic_region':
           return area.name + ' (Ethnolinguistic Region)'
         case 'fire_zone':
-          return area.name + ' (Fire Management Unit)'
+          return area.name + ' (Alaska Fire Management Unit)'
         case 'yt_fire_district':
           return area.name + ' (Yukon Fire District)'
         case 'first_nation':
           return area.name + ' (First Nation Traditional Territory)'
         case 'game_management_unit':
-          return area.name + ' (Game Management Unit)'
+          return area.name + ' (Alaska Game Management Unit)'
         case 'yt_game_management_subzone':
           return area.name + ' (Yukon Game Management Subzone)'
         case 'borough':


### PR DESCRIPTION
Closes #697.

This PR closes parts 1 & 2 of #697. I agree with Mike's assessment that part 3 of #697 is better handled in the GVV repo, so I've made a ticket for that: https://github.com/ua-snap/geospatial-vector-veracity/issues/164

This PR:

- Renames the "Game Management Unit" area category label to "Alaska Game Management Unit" to disambiguate it from the "Yukon Game Management Subzone" area category label.
- Renames the "Fire Management Unit" area category label to "Alaska Fire Management Unit" to disambiguate it from the "Yukon Fire District" area category label.
- Combines HUCs and Yukon Watersheds under the same section of map search results, and this section of the search results has been renamed from "Hydrological units (HUCs)" to "Watersheds".

This PR doesn't require a development/local version of the API, so to test, simply run the app with `npm run dev`. Observe that the new "Alaska Game Management Unit" & "Alaska Fire Management Unit" category labels show up in:

- The place selector dropdown menu
- The map search interface
- Above the loading indicator when a report is loading
- On the report pages themselves

And if you click a point on the map search interface close to the Alaska/Yukon border, you'll see both types of watersheds combined under the same "Watersheds" category.