### PR TITLE
Round indicator diffs to one decimal place in DayDiffWidget.vue

### DIFF
--- a/components/reports/DayDiffWidget.vue
+++ b/components/reports/DayDiffWidget.vue
@@ -53,7 +53,7 @@ export default {
       return this.pct > 0
     },
     diff() {
-      let diff = (this.future - this.past).toFixed(1)
+      let diff = _.round(this.future - this.past, 1)
       if (diff > 0) {
         diff = '&plus;' + diff
       } else if (diff < 0) {

--- a/components/reports/DayDiffWidget.vue
+++ b/components/reports/DayDiffWidget.vue
@@ -53,7 +53,7 @@ export default {
       return this.pct > 0
     },
     diff() {
-      let diff = this.future - this.past
+      let diff = (this.future - this.past).toFixed(1)
       if (diff > 0) {
         diff = '&plus;' + diff
       } else if (diff < 0) {


### PR DESCRIPTION
This PR rounds the difference calculation of day-based indicators to one decimal place, and hides the decimal if the difference is a whole number. This solves the problem we (mysteriously) started seeing recently where the day difference was often an extremely long float value with ~14 decimal places, and stretching the indicators table outside its container div.

To test, run the webapp and try loading a report for a point location and also an area location:

- Day-based indicators for point locations are always whole numbers, so you can see how this PR does not force a decimal place when dealing with whole number differences.
- Day-based indicators for area locations are usually not whole numbers because they are the average over an area. Observe how the difference values are rounded to one decimal place when necessary.