### PR TITLE
Add support (and Playwright test) for new Ecoregion area type

### DIFF
--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -93,6 +93,12 @@
                 >
                   Borough
                 </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'ecoregion'"
+                >
+                  Ecoregion
+                </span>
                 <span class="area-additional-info">
                   {{ props.option.region }}
                 </span>

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -170,6 +170,9 @@ export default {
         case 'ethnolinguistic_region':
           placeType = 'Ethnolinguistic Region'
           break
+        case 'ecoregion':
+          placeType = 'Ecoregion'
+          break
         default: // Do nothing, don't decorate protected areas
       }
       return placeType

--- a/store/place.js
+++ b/store/place.js
@@ -149,6 +149,8 @@ export const getters = {
           return area.name + ' (Yukon Game Management Subzone)'
         case 'borough':
           return area.name + ' (Borough)'
+        case 'ecoregion':
+          return area.name + ' (Ecoregion)'
         default:
           return area.name
       }
@@ -292,6 +294,9 @@ export const actions = {
           ssr.push(place)
         })
         _.each(res.ethnolinguistic_regions_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.ecoregions_near, place => {
           ssr.push(place)
         })
 

--- a/tests/test-suite.spec.js
+++ b/tests/test-suite.spec.js
@@ -171,6 +171,7 @@ test('Check for expected place types in place selector', async ({ page }) => {
     'BC Provincial Park - Protected Area',
     'BC Provincial Park - Recreation Area',
     'Ecological Reserve',
+    'Ecoregion',
     'Habitat Protection Area',
     'National Conservation Area (BLM)',
     'National Forest (USFS)',

--- a/utils/path.js
+++ b/utils/path.js
@@ -15,7 +15,8 @@ export const getAppPathFragment = function (type, id) {
     type == 'yt_game_management_subzone' ||
     type == 'borough' ||
     type == 'census_area' ||
-    type == 'yt_watershed'
+    type == 'yt_watershed' ||
+    type == 'ecoregion'
   ) {
     path = '/report/area/' + id
   } else {


### PR DESCRIPTION
Closes #747.

This PR adds support for the new `ecoregion` type served from the Data API, including:

- Adding the decorative "Ecoregion" label to ecoregions in the place selector
- Recognizing `ecoregion` as an area type in `utils/path.js` so the webapp doesn't crash
- Including ecoregions (with "Ecoregion" label) in map search results
- Adding " (Ecoregion)" after the ecoregion name on loading/report pages

I've also added "Ecoregion" to the expected place types in the "Check for expected place types in place selector" test in the Playwright test suite, so the test will verify that this fix is in place.

To test, run the app with `export SNAP_API_URL=https://testcache.earthmaps.io`, then:

- Enter "Arctic" into the place selector and select one of the ecoregion places near the bottom. Verify that the report for the ecoregion loads successfully.
- Click the map search interface basically anywhere in Alaska and verify that ecoregion show up in the results.